### PR TITLE
Update paket.dependencies

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,4 +2,4 @@ source https://api.nuget.org/v3/index.json
 
 storage: none
 framework: netcoreapp3.1, netstandard2.0, netstandard2.1
-nuget Deedle
+nuget Deedle >= 2.2.0


### PR DESCRIPTION
This should fix the dependency string displayed on nuget:

![image](https://user-images.githubusercontent.com/21338071/92460224-005bf080-f1c8-11ea-8b78-95d57a968e5d.png)
